### PR TITLE
fix(гейт): снятие состояния переживает пути с не-ASCII символами

### DIFF
--- a/hooks/gate-arm.mjs
+++ b/hooks/gate-arm.mjs
@@ -10,10 +10,11 @@
  * Любая внутренняя ошибка — молча exit 0: хук качества не имеет права ломать работу.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readPayload, projectRoot, toProjectRelative } from './_shared.mjs';
+import { removeFileSync } from '../tools/fs-safe.mjs';
 import { ensureConfig } from '../tools/config.mjs';
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -137,12 +138,12 @@ function main() {
       if (done?.sessions) {
         delete done.sessions[sessionId];
         if (Object.keys(done.sessions).length) writeFileSync(donePath, JSON.stringify(done, null, 2), 'utf8');
-        else rmSync(donePath, { force: true });
+        else removeFileSync(donePath);
       } else {
-        rmSync(donePath, { force: true });
+        removeFileSync(donePath);
       }
     } catch {
-      rmSync(donePath, { force: true });
+      removeFileSync(donePath);
     }
   }
 

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -19,6 +19,7 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { removeTreeSync } from '../tools/fs-safe.mjs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -75,7 +76,7 @@ function writeBytes(name, content) {
   return p;
 }
 
-rmSync(WORK, { recursive: true, force: true });
+removeTreeSync(WORK);
 mkdirSync(WORK, { recursive: true });
 
 // ---------------------------------------------------------------------------
@@ -3271,10 +3272,68 @@ section('Версия плагина в выводе инструментов');
 }
 
 // ---------------------------------------------------------------------------
+section('Удаление состояния на путях с не-ASCII символами');
+
+{
+  // На Node 24.x/Windows `fs.rmSync` молча не удаляет пути с не-ASCII символами
+  // (nodejs/node#56049): release печатал «гейт снят», маркер оставался, Stop блокировал
+  // завершение навсегда. Кириллическое имя проекта для 1С — норма, поэтому здесь
+  // фиксируется КОНТРАКТ: после удаления пути не существует — на любой версии Node.
+  const fsSafe = await import(pathToFileURL(join(ROOT, 'tools', 'fs-safe.mjs')).href);
+
+  const cyrDir = join(WORK, 'проект-кириллица');
+  fsSafe.removeTreeSync(cyrDir);
+  mkdirSync(join(cyrDir, '.claude', '.state'), { recursive: true });
+  const marker = join(cyrDir, '.claude', '.state', 'qg-pending.json');
+  writeFileSync(marker, '{}', 'utf8');
+  check('removeFileSync удаляет файл на кириллическом пути', fsSafe.removeFileSync(marker) === true && !existsSync(marker));
+  check('removeFileSync отсутствующего файла — успех', fsSafe.removeFileSync(marker) === true);
+
+  writeFileSync(join(cyrDir, 'вложенный файл.txt'), 'x', 'utf8');
+  check('removeTreeSync удаляет дерево с кириллицей внутри', fsSafe.removeTreeSync(cyrDir) === true && !existsSync(cyrDir));
+
+  // Интеграция: полный цикл взвода и снятия в проекте с кириллическим именем.
+  // Без removeFileSync в release этот тест на Node 24.x/Windows падал: маркер переживал
+  // «успешное» снятие, а повторный Stop возвращал блокировку.
+  const proj = join(WORK, 'проект-релиз');
+  fsSafe.removeTreeSync(proj);
+  mkdirSync(join(proj, 'src', 'cf', 'CommonModules', 'М', 'Ext'), { recursive: true });
+  const env = { CLAUDE_PROJECT_DIR: proj };
+  const file = join(proj, 'src', 'cf', 'CommonModules', 'М', 'Ext', 'Module.bsl');
+  try {
+    execFileSync(process.execPath, [join(ROOT, 'hooks', 'gate-arm.mjs')], {
+      input: JSON.stringify({ session_id: 'КИР', cwd: proj, tool_input: { file_path: file } }),
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    });
+  } catch {
+    /* arm никогда не падает — а если упал, ниже это видно по отсутствию маркера */
+  }
+  const pendingPath = join(proj, '.claude', '.state', 'qg-pending.json');
+  check('гейт взведён в кириллическом проекте', existsSync(pendingPath));
+  const rel = run('tools/gate.mjs', ['release', '--session', 'КИР', '--class', 'C0', '--reason', 'тест контракта удаления'], { env });
+  check('release в кириллическом проекте снял гейт и подтвердил это', rel.code === 0 && !existsSync(pendingPath), `code=${rel.code}, pending=${existsSync(pendingPath)}`);
+  check('журнал снятий записан', existsSync(join(proj, '.claude', '.state', 'qg-done.json')));
+  let stopCode = 0;
+  try {
+    execFileSync(process.execPath, [join(ROOT, 'hooks', 'gate-check.mjs')], {
+      input: JSON.stringify({ session_id: 'КИР', cwd: proj }),
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    stopCode = e.status ?? 1;
+  }
+  check('Stop после снятия не блокирует', stopCode === 0, `code=${stopCode}`);
+  fsSafe.removeTreeSync(proj);
+}
+
+// ---------------------------------------------------------------------------
 process.stdout.write(`\n${'='.repeat(60)}\nПройдено: ${passed}, провалено: ${failures.length}\n`);
 if (failures.length) {
   process.stdout.write('\nПровалившиеся проверки:\n');
   for (const f of failures) process.stdout.write(`  - ${f.name}${f.detail ? ` (${f.detail})` : ''}\n`);
 }
-rmSync(WORK, { recursive: true, force: true });
+removeTreeSync(WORK);
 process.exit(failures.length ? 1 : 0);

--- a/tools/analyzer-bootstrap.mjs
+++ b/tools/analyzer-bootstrap.mjs
@@ -17,7 +17,8 @@
  *   node analyzer-bootstrap.mjs [--force] [--verify]
  */
 
-import { createWriteStream, createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, rmSync, chmodSync, statSync } from 'node:fs';
+import { createWriteStream, createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, chmodSync, statSync } from 'node:fs';
+import { removeFileSync } from './fs-safe.mjs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
@@ -138,20 +139,20 @@ export async function install(manifest, { root = dataRoot(), force = false, log 
     if (!response.ok || !response.body) {
       return { ok: false, reason: 'download_failed', status: response.status };
     }
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     await pipeline(Readable.fromWeb(response.body), createWriteStream(tmpPath));
   } catch (e) {
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     return { ok: false, reason: 'download_failed', error: String(e.message || e) };
   }
 
   const actual = await sha256(tmpPath);
   if (actual !== target.sha256) {
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     return { ok: false, reason: 'checksum_mismatch', actual, expected: target.sha256 };
   }
 
-  rmSync(finalPath, { force: true });
+  removeFileSync(finalPath);
   renameSync(tmpPath, finalPath);
   if (process.platform !== 'win32') chmodSync(finalPath, 0o755);
   writeMarker(manifest, root, { sha256: actual, size: statSync(finalPath).size, installedFrom: url });

--- a/tools/analyzer-run.mjs
+++ b/tools/analyzer-run.mjs
@@ -32,7 +32,8 @@
  * 2 — обязателен и недоступен, либо часовой не подтверждён.
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdtempSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, mkdirSync, readdirSync } from 'node:fs';
+import { removeTreeSync } from './fs-safe.mjs';
 import { join, dirname, resolve, relative, sep, isAbsolute, basename } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
@@ -458,10 +459,10 @@ export function runBslLs({ jar, root, configPath }) {
   const report = join(out, 'bsl-json.json');
   const text = existsSync(report) ? readFileSync(report, 'utf8') : '';
   try {
-    rmSync(out, { recursive: true, force: true });
+    removeTreeSync(out);
     // Промежуточный каталог убираем ТОЛЬКО пустым: параллельный прогон может держать в нём
     // свой отчёт, и рекурсивное удаление снесло бы чужой результат.
-    if (readdirSync(stage).length === 0) rmSync(stage, { recursive: true, force: true });
+    if (readdirSync(stage).length === 0) removeTreeSync(stage);
   } catch {
     /* уборка не критична */
   }

--- a/tools/fs-safe.mjs
+++ b/tools/fs-safe.mjs
@@ -1,0 +1,75 @@
+/**
+ * Надёжное удаление файлов и каталогов — с проверкой, что удаление состоялось.
+ *
+ * Зачем отдельный модуль. В Node 24.x на Windows `fs.rmSync` МОЛЧА не удаляет файл или
+ * каталог, если в пути есть не-ASCII символы (кириллица в имени проекта — обычное дело
+ * для 1С): ни исключения, ни удаления (nodejs/node#56049, nodejs/node#61067; исправления
+ * в апстриме есть, но до установленных версий доходят не сразу). Для гейта это фатально:
+ * `release` рапортовал «гейт снят», `qg-pending.json` оставался на месте — и Stop-хук
+ * блокировал завершение навсегда. Ровно тот класс отказа, против которого написан весь
+ * плагин: успех, не отличимый от невыполнения.
+ *
+ * Поэтому здесь два правила:
+ *   1) файлы удаляются `unlinkSync` — он не поражён этим дефектом;
+ *   2) после любого удаления результат ПРОВЕРЯЕТСЯ (`existsSync`), а для деревьев при
+ *      живом остатке выполняется ручной обход `unlinkSync` + `rmdirSync` — оба здоровы
+ *      на не-ASCII путях (проверено на Node 24.12.0 win32).
+ *
+ * Обе функции возвращают `true`, только если пути больше не существует. Вызывающий обязан
+ * смотреть на результат там, где от удаления зависит смысл сообщения пользователю.
+ */
+
+import { existsSync, unlinkSync, rmSync, rmdirSync, readdirSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Удаляет ФАЙЛ и подтверждает удаление. Отсутствующий файл — успех (удалять нечего).
+ */
+export function removeFileSync(path) {
+  try {
+    unlinkSync(path);
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') return !existsSync(path);
+  }
+  return !existsSync(path);
+}
+
+/** Ручной обход дерева: unlink для файлов, rmdir для опустевших каталогов. */
+function removeTreeManual(path) {
+  let st;
+  try {
+    st = lstatSync(path);
+  } catch {
+    return; // уже нет — и хорошо
+  }
+  if (st.isDirectory() && !st.isSymbolicLink()) {
+    for (const entry of readdirSync(path)) removeTreeManual(join(path, entry));
+    try {
+      rmdirSync(path);
+    } catch {
+      /* итог проверит вызывающий */
+    }
+  } else {
+    try {
+      unlinkSync(path);
+    } catch {
+      /* итог проверит вызывающий */
+    }
+  }
+}
+
+/**
+ * Удаляет дерево (файл или каталог) и подтверждает удаление.
+ *
+ * Сначала штатный `rmSync` — на здоровых путях он быстрее и переживает ситуации,
+ * которые ручной обход не знает. Затем проверка; остаток добирается ручным обходом.
+ */
+export function removeTreeSync(path) {
+  try {
+    rmSync(path, { recursive: true, force: true });
+  } catch {
+    /* добьём обходом ниже */
+  }
+  if (existsSync(path)) removeTreeManual(path);
+  return !existsSync(path);
+}

--- a/tools/gate.mjs
+++ b/tools/gate.mjs
@@ -12,11 +12,12 @@
  *   node gate.mjs release --class C0 --reason "<...>"  # снять как не требующий проверки
  */
 
-import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { validate } from './evidence-validator.mjs';
 import { resolveProjectRoot } from './project-root.mjs';
 import { readConfig, versionSuffix, pluginVersion } from './config.mjs';
+import { removeFileSync } from './fs-safe.mjs';
 
 const STATE_DIR = ['.claude', '.state'];
 const PENDING = 'qg-pending.json';
@@ -274,11 +275,24 @@ function cmdRelease(args) {
 
   // Снимаем ТОЛЬКО свою сессию: записи остальных остаются взведёнными, за них отвечают
   // их владельцы. Если своя была последней — файл состояния удаляется целиком.
+  //
+  // Удаление обязано ПОДТВЕРДИТЬСЯ до того, как пользователю сказано «гейт снят»:
+  // на Node 24.x/Windows `rmSync` молча не удаляет файлы на путях с не-ASCII символами
+  // (кириллическое имя проекта — норма для 1С), и без проверки release рапортовал успех,
+  // а Stop-хук продолжал блокировать завершение. Успех, не отличимый от невыполнения, —
+  // ровно тот класс отказа, против которого написан весь плагин.
   delete state.sessions[sessionId];
   if (Object.keys(state.sessions).length) {
     writeFileSync(pending, JSON.stringify(state, null, 2), 'utf8');
-  } else {
-    rmSync(pending, { force: true });
+  } else if (!removeFileSync(pending)) {
+    process.stderr.write(
+      'Маркер гейта не удалился — гейт НЕ снят:\n' +
+        `  ${pending}\n` +
+        'Известная причина: fs.rmSync в Node 24.x на Windows молча пропускает пути\n' +
+        'с не-ASCII символами (nodejs/node#56049). Обнови Node до версии с исправлением\n' +
+        'либо удали файл вручную и повтори снятие.\n'
+    );
+    return 2;
   }
 
   let doneState = { version: 2, sessions: {} };


### PR DESCRIPTION
## Что сломано

`gate.mjs release` печатает «Гейт снят», пишет журнал снятий — а `qg-pending.json` остаётся на месте, и Stop-хук блокирует завершение навсегда. Воспроизводится на любом проекте, в чьём пути есть не-ASCII символы (кириллическое имя каталога — норма для 1С).

Причина не в плагине: в Node 24.x на Windows `fs.rmSync` **молча не удаляет** файл или каталог, если в пути есть не-ASCII символы — ни исключения, ни удаления (nodejs/node#56049, nodejs/node#61067; исправления в апстриме Node есть, но до установленных версий доезжают не сразу). `unlinkSync` и `rmdirSync` этим дефектом не поражены — проверено на Node 24.12.0/win32 минимальным репро.

Плагин при этом рапортует успех, не проверяя собственный эффект, — ровно тот класс отказа («успех, не отличимый от невыполнения»), против которого написан весь проект. CI на Node 20 этого не ловит: дефект появился в более поздних версиях Node.

## Что сделано

- Новый `tools/fs-safe.mjs`: `removeFileSync` (`unlinkSync` + подтверждение `existsSync`) и `removeTreeSync` (`rmSync`, затем ручной обход `unlinkSync`/`rmdirSync` при живом остатке). Обе функции возвращают `true` только если пути больше не существует.
- Все места удаления состояния переведены на них: `gate.mjs` (маркер pending), `gate-arm.mjs` (журнал done), `analyzer-bootstrap.mjs` (временные файлы кэша), `analyzer-run.mjs` (каталоги выгрузки анализатора).
- `release` теперь **проверяет**, что маркер действительно исчез; при живом маркере — честный отказ с кодом 2 и указанием причины вместо ложного «гейт снят».
- Финальная уборка тестового каталога тоже через `removeTreeSync` — иначе кириллические фикстуры переживали прогон.

## Проверки

- `node tests/run-tests.mjs` — 574/0 на Node 24.12.0/win32; новая секция «Удаление состояния на путях с не-ASCII символами»: контракт удаления + интеграционный цикл взвод → release → Stop в проекте с кириллическим именем.
- Негативный контроль: с откаченным `gate.mjs` новые тесты падают ровно на симптоме бага (`release … code=0, pending=true`; `Stop … code=2`) — проверено обоими прогонами.
- `node tools/validate-package.mjs` — чисто.
