### PR TITLE
feat(гейт): classifyFile понимает формат EDT и выгрузку конфигуратора без src

### DIFF
--- a/hooks/gate-arm.mjs
+++ b/hooks/gate-arm.mjs
@@ -23,6 +23,18 @@ const PENDING = 'qg-pending.json';
 const DONE = 'qg-done.json';
 
 /**
+ * Типовые каталоги объектов метаданных в выгрузках 1С (нижний регистр).
+ * Один список на все проверки ниже: раздвоенный, он разойдётся при первом же
+ * добавлении нового вида объектов.
+ */
+const METADATA_DIRS =
+  'catalogs|documents|informationregisters|accumulationregisters|commonmodules|dataprocessors|reports|enums|chartsofcharacteristictypes|businessprocesses|tasks|exchangeplans|roles|subsystems';
+
+const RE_META_UNDER_SRC_NESTED = new RegExp(`(^|/)src/.*/(${METADATA_DIRS})/`);
+const RE_META_UNDER_SRC_DIRECT = new RegExp(`(^|/)src/(${METADATA_DIRS})/`);
+const RE_META_DIR_SEGMENT = new RegExp(`(^|/)(${METADATA_DIRS})/`);
+
+/**
  * Определяет, файл какого рода затронут.
  * Возвращает null для всего, что не относится к 1С, — в не-1С проектах плагин молчит.
  */
@@ -31,6 +43,13 @@ function classifyFile(filePath) {
   const lower = p.toLowerCase();
 
   if (lower.endsWith('.bsl') || lower.endsWith('.os')) return 'bsl';
+
+  // Формат EDT: метаданные — .mdo, формы — .form. Правка руками мимо модели EDT ломает
+  // проект так же, как правка XML выгрузки, поэтому класс тот же — metadata-xml.
+  // .mdo достаточно однозначен сам по себе; .form встречается и вне 1С, поэтому
+  // принимается только внутри src/ — EDT другой раскладки не создаёт.
+  if (lower.endsWith('.mdo')) return 'metadata-xml';
+  if (lower.endsWith('.form') && /(^|\/)src\//.test(lower)) return 'metadata-xml';
 
   if (lower.endsWith('.xml')) {
     // Configuration.xml — корень выгрузки конфигурации, однозначный маркер 1С.
@@ -42,9 +61,28 @@ function classifyFile(filePath) {
     // гейт на каждый их XML.
     if (/(^|\/)(cf|cfe)\//.test(lower)) return 'metadata-xml';
 
-    // Выгрузка EDT/конфигуратора внутри src: src/<Имя>/... с типовыми каталогами объектов.
-    if (/(^|\/)src\/.*\/(catalogs|documents|informationregisters|accumulationregisters|commonmodules|dataprocessors|reports|enums|chartsofcharacteristictypes|businessprocesses|tasks|exchangeplans|roles|subsystems)\//.test(lower)) {
+    // Выгрузка внутри src: и src/<Имя>/Catalogs/… (несколько конфигураций в репозитории),
+    // и src/Catalogs/… — раскладка EDT-проекта и репозиториев с одной конфигурацией.
+    // Типовой каталог объектов сразу за src/ в чужих экосистемах не встречается,
+    // поэтому здесь дополнительное подтверждение не требуется.
+    if (RE_META_UNDER_SRC_NESTED.test(lower) || RE_META_UNDER_SRC_DIRECT.test(lower)) {
       return 'metadata-xml';
+    }
+
+    // Выгрузка конфигуратора БЕЗ src: DumpConfigToFiles пишет Catalogs/, Documents/ и
+    // Configuration.xml прямо в целевой каталог. Одного имени типового каталога мало
+    // (мало ли у кого есть documents/) — поэтому требуется подтверждение на диске:
+    // рядом с типовым каталогом обязан лежать Configuration.xml. Проверка по факту,
+    // а не по строке пути, — иначе гейт взводился бы в чужих проектах.
+    const m = RE_META_DIR_SEGMENT.exec(lower);
+    if (m) {
+      const idx = lower.indexOf(m[2] + '/', m.index);
+      const dumpRoot = p.slice(0, idx);
+      try {
+        if (existsSync(join(dumpRoot, 'Configuration.xml'))) return 'metadata-xml';
+      } catch {
+        /* недоступный диск не повод для гейта */
+      }
     }
 
     return null;
@@ -69,9 +107,10 @@ const HINTS = {
     'Файл: %FILE%',
     '',
     'Перед завершением работы прогони Skill: quality-gate.',
-    'Для нового объекта критична проверка регистрации в Configuration.xml:',
-    'файл-сирота вне <ChildObjects> не попадает в сборку, при этом конфигуратор',
-    'её не диагностирует — ошибка всплывает только в рантайме.',
+    'Для нового объекта критична проверка регистрации в составе конфигурации',
+    '(Configuration.xml выгрузки либо Configuration.mdo в проекте EDT): файл-сирота',
+    'вне состава не попадает в сборку, при этом среда этого не диагностирует —',
+    'ошибка всплывает только в рантайме.',
     '',
     'Завершение сессии заблокировано, пока гейт не снят.',
   ],

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -3271,6 +3271,81 @@ section('Версия плагина в выводе инструментов');
 }
 
 // ---------------------------------------------------------------------------
+section('Классификация форматов 1С: EDT и выгрузка конфигуратора');
+
+{
+  // Гейт обязан взводиться на ВСЕХ рабочих раскладках исходников 1С, а не только на
+  // выгрузке вида src/<Имя>/Catalogs. До этой секции формат EDT (.mdo, .form,
+  // src/Catalogs без промежуточного сегмента) и выгрузка конфигуратора без src/
+  // проходили мимо classifyFile: правка метаданных не взводила гейт вовсе.
+  const proj = join(WORK, 'classify-proj');
+  rmSync(proj, { recursive: true, force: true });
+  const env = { CLAUDE_PROJECT_DIR: proj };
+
+  const arm = (path, sessionId) => {
+    try {
+      execFileSync(process.execPath, [join(ROOT, 'hooks', 'gate-arm.mjs')], {
+        input: JSON.stringify({ session_id: sessionId, cwd: proj, tool_input: { file_path: path } }),
+        encoding: 'utf8',
+        env: { ...process.env, ...env },
+      });
+    } catch {
+      /* arm не падает; результат читается из маркера */
+    }
+    const pendingPath = join(proj, '.claude', '.state', 'qg-pending.json');
+    if (!existsSync(pendingPath)) return null;
+    const state = JSON.parse(readFileSync(pendingPath, 'utf8'));
+    const files = state.sessions?.[sessionId]?.files || {};
+    const entry = Object.entries(files).find(([k]) => path.replace(/\\/g, '/').endsWith(k));
+    return entry ? entry[1].kind : null;
+  };
+
+  // Формат EDT: метаданные и формы.
+  const mdo = join(proj, 'src', 'Catalogs', 'Валюты', 'Валюты.mdo');
+  mkdirSync(dirname(mdo), { recursive: true });
+  writeFileSync(mdo, '<mdclass/>', 'utf8');
+  check('EDT .mdo взводит гейт как metadata-xml', arm(mdo, 'EDT1') === 'metadata-xml');
+
+  const form = join(proj, 'src', 'Catalogs', 'Валюты', 'Forms', 'ФормаЭлемента', 'Form.form');
+  mkdirSync(dirname(form), { recursive: true });
+  writeFileSync(form, '<form/>', 'utf8');
+  check('EDT .form внутри src взводит гейт', arm(form, 'EDT2') === 'metadata-xml');
+
+  const strayForm = join(proj, 'templates', 'letter.form');
+  mkdirSync(dirname(strayForm), { recursive: true });
+  writeFileSync(strayForm, 'x', 'utf8');
+  check('.form вне src гейт не взводит', arm(strayForm, 'EDT3') === null);
+
+  // Раскладка src/Catalogs/… без промежуточного сегмента (EDT и репозитории
+  // с одной конфигурацией).
+  const srcXml = join(proj, 'src', 'Catalogs', 'Товары.xml');
+  writeFileSync(srcXml, '<x/>', 'utf8');
+  check('XML в src/Catalogs без сегмента взводит гейт', arm(srcXml, 'SRC1') === 'metadata-xml');
+
+  // Выгрузка конфигуратора без src: подтверждением служит Configuration.xml рядом.
+  const dump = join(proj, 'выгрузка');
+  mkdirSync(join(dump, 'Catalogs'), { recursive: true });
+  const dumpXml = join(dump, 'Catalogs', 'Товары.xml');
+  writeFileSync(dumpXml, '<x/>', 'utf8');
+  check('выгрузка без src и без Configuration.xml молчит', arm(dumpXml, 'DUMP1') === null);
+  writeFileSync(join(dump, 'Configuration.xml'), '<x/>', 'utf8');
+  check('выгрузка без src при Configuration.xml рядом взводит гейт', arm(dumpXml, 'DUMP2') === 'metadata-xml');
+
+  // Чужой проект: типовое имя каталога само по себе гейт не взводит.
+  const alien = join(proj, 'backend', 'documents', 'invoice.xml');
+  mkdirSync(dirname(alien), { recursive: true });
+  writeFileSync(alien, '<x/>', 'utf8');
+  check('чужой documents/ без Configuration.xml молчит', arm(alien, 'ALIEN1') === null);
+
+  const alienSrc = join(proj, 'app', 'src', 'main', 'resources', 'beans.xml');
+  mkdirSync(dirname(alienSrc), { recursive: true });
+  writeFileSync(alienSrc, '<x/>', 'utf8');
+  check('java-style src/main/resources молчит', arm(alienSrc, 'ALIEN2') === null);
+
+  rmSync(proj, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
 process.stdout.write(`\n${'='.repeat(60)}\nПройдено: ${passed}, провалено: ${failures.length}\n`);
 if (failures.length) {
   process.stdout.write('\nПровалившиеся проверки:\n');


### PR DESCRIPTION
## Что сломано

Гейт взводится не на всех рабочих раскладках исходников 1С. Проверено живыми правками:

- **проект EDT**: `.mdo` и `.form` не классифицируются вовсе, а метаданные лежат в `src/Catalogs/…` — сразу за `src`, без промежуточного сегмента, который требует текущий паттерн `src/<Имя>/Catalogs/…`. Итог: на EDT-проекте гейт видит только `.bsl`, правка метаданных проходит мимо;
- **выгрузка конфигуратора** (`DumpConfigToFiles`) без `src/`: `Catalogs/Товары.xml` в каталоге выгрузки не взводит гейт — ловится только сам `Configuration.xml` по имени файла.

## Что сделано

- `.mdo` → `metadata-xml` всегда; `.form` → только внутри `src/` (расширение встречается вне 1С, а EDT другой раскладки не создаёт).
- `src/Catalogs/…` принимается наравне с `src/<Имя>/Catalogs/…`.
- Выгрузка без `src/` принимается **только с подтверждением на диске**: рядом с типовым каталогом обязан лежать `Configuration.xml`. Проверка по факту, а не по строке пути, — чтобы плагин молчал в чужих проектах, где `documents/` значит совсем другое.
- Список типовых каталогов вынесен в одну константу для всех проверок (раздвоенный список разошёлся бы при первом добавлении нового вида объектов).
- Подсказка про регистрацию нового объекта упоминает и `Configuration.mdo` проекта EDT.

## Проверки

- `node tests/run-tests.mjs` — 575/0; новая секция «Классификация форматов 1С»: оба формата, граница `.form` вне `src`, выгрузка с подтверждением и без, чужие `documents/` и `src/main/resources`.
- Негативный контроль: с откаченным `classifyFile` падают ровно четыре новые возможности, граничные и регресс-проверки остаются зелёными.
- `node tools/validate-package.mjs` — чисто.
