### PR TITLE
fix(гейт): снятие состояния переживает пути с не-ASCII символами (перенос #3 на текущий main)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,13 +7,29 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    # Матрица не декоративна. Инструменты плагина запускаются тем `node`, что стоит у
+    # пользователя, и на разных парах «ОС + версия» ведут себя по-разному: fs.rmSync в
+    # Node 23/24 на Windows МОЛЧА не удаляет пути с не-ASCII символами (nodejs/node#61067),
+    # а кириллица в имени проекта 1С — норма. Прогон только на ubuntu+20 такой отказ не видит.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: ["20", "24"]
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        # Единый синтаксис шагов на обеих ОС: на windows-latest оболочка по умолчанию — pwsh.
+        shell: bash
+
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node }}
 
       - uses: actions/setup-python@v7
         with:

--- a/hooks/gate-arm.mjs
+++ b/hooks/gate-arm.mjs
@@ -10,10 +10,11 @@
  * Любая внутренняя ошибка — молча exit 0: хук качества не имеет права ломать работу.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readPayload, projectRoot, toProjectRelative } from './_shared.mjs';
+import { removeFileSync } from '../tools/fs-safe.mjs';
 import { ensureConfig } from '../tools/config.mjs';
 
 const PLUGIN_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -176,12 +177,12 @@ function main() {
       if (done?.sessions) {
         delete done.sessions[sessionId];
         if (Object.keys(done.sessions).length) writeFileSync(donePath, JSON.stringify(done, null, 2), 'utf8');
-        else rmSync(donePath, { force: true });
+        else removeFileSync(donePath);
       } else {
-        rmSync(donePath, { force: true });
+        removeFileSync(donePath);
       }
     } catch {
-      rmSync(donePath, { force: true });
+      removeFileSync(donePath);
     }
   }
 

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -19,6 +19,7 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { removeTreeSync } from '../tools/fs-safe.mjs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { execFileSync } from 'node:child_process';
@@ -75,7 +76,7 @@ function writeBytes(name, content) {
   return p;
 }
 
-rmSync(WORK, { recursive: true, force: true });
+removeTreeSync(WORK);
 mkdirSync(WORK, { recursive: true });
 
 // ---------------------------------------------------------------------------
@@ -3426,10 +3427,68 @@ section('Классификация форматов 1С: EDT и выгрузк�
 }
 
 // ---------------------------------------------------------------------------
+section('Удаление состояния на путях с не-ASCII символами');
+
+{
+  // На Node 24.x/Windows `fs.rmSync` молча не удаляет пути с не-ASCII символами
+  // (nodejs/node#56049): release печатал «гейт снят», маркер оставался, Stop блокировал
+  // завершение навсегда. Кириллическое имя проекта для 1С — норма, поэтому здесь
+  // фиксируется КОНТРАКТ: после удаления пути не существует — на любой версии Node.
+  const fsSafe = await import(pathToFileURL(join(ROOT, 'tools', 'fs-safe.mjs')).href);
+
+  const cyrDir = join(WORK, 'проект-кириллица');
+  fsSafe.removeTreeSync(cyrDir);
+  mkdirSync(join(cyrDir, '.claude', '.state'), { recursive: true });
+  const marker = join(cyrDir, '.claude', '.state', 'qg-pending.json');
+  writeFileSync(marker, '{}', 'utf8');
+  check('removeFileSync удаляет файл на кириллическом пути', fsSafe.removeFileSync(marker) === true && !existsSync(marker));
+  check('removeFileSync отсутствующего файла — успех', fsSafe.removeFileSync(marker) === true);
+
+  writeFileSync(join(cyrDir, 'вложенный файл.txt'), 'x', 'utf8');
+  check('removeTreeSync удаляет дерево с кириллицей внутри', fsSafe.removeTreeSync(cyrDir) === true && !existsSync(cyrDir));
+
+  // Интеграция: полный цикл взвода и снятия в проекте с кириллическим именем.
+  // Без removeFileSync в release этот тест на Node 24.x/Windows падал: маркер переживал
+  // «успешное» снятие, а повторный Stop возвращал блокировку.
+  const proj = join(WORK, 'проект-релиз');
+  fsSafe.removeTreeSync(proj);
+  mkdirSync(join(proj, 'src', 'cf', 'CommonModules', 'М', 'Ext'), { recursive: true });
+  const env = { CLAUDE_PROJECT_DIR: proj };
+  const file = join(proj, 'src', 'cf', 'CommonModules', 'М', 'Ext', 'Module.bsl');
+  try {
+    execFileSync(process.execPath, [join(ROOT, 'hooks', 'gate-arm.mjs')], {
+      input: JSON.stringify({ session_id: 'КИР', cwd: proj, tool_input: { file_path: file } }),
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    });
+  } catch {
+    /* arm никогда не падает — а если упал, ниже это видно по отсутствию маркера */
+  }
+  const pendingPath = join(proj, '.claude', '.state', 'qg-pending.json');
+  check('гейт взведён в кириллическом проекте', existsSync(pendingPath));
+  const rel = run('tools/gate.mjs', ['release', '--session', 'КИР', '--class', 'C0', '--reason', 'тест контракта удаления'], { env });
+  check('release в кириллическом проекте снял гейт и подтвердил это', rel.code === 0 && !existsSync(pendingPath), `code=${rel.code}, pending=${existsSync(pendingPath)}`);
+  check('журнал снятий записан', existsSync(join(proj, '.claude', '.state', 'qg-done.json')));
+  let stopCode = 0;
+  try {
+    execFileSync(process.execPath, [join(ROOT, 'hooks', 'gate-check.mjs')], {
+      input: JSON.stringify({ session_id: 'КИР', cwd: proj }),
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    stopCode = e.status ?? 1;
+  }
+  check('Stop после снятия не блокирует', stopCode === 0, `code=${stopCode}`);
+  fsSafe.removeTreeSync(proj);
+}
+
+// ---------------------------------------------------------------------------
 process.stdout.write(`\n${'='.repeat(60)}\nПройдено: ${passed}, провалено: ${failures.length}\n`);
 if (failures.length) {
   process.stdout.write('\nПровалившиеся проверки:\n');
   for (const f of failures) process.stdout.write(`  - ${f.name}${f.detail ? ` (${f.detail})` : ''}\n`);
 }
-rmSync(WORK, { recursive: true, force: true });
+removeTreeSync(WORK);
 process.exit(failures.length ? 1 : 0);

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -2464,6 +2464,18 @@ section('Чужая установка принимается, только ес
 
   const gone = await boot.adopt(fake, join(launcher, 'нет-такого'), { root: join(WORK, 'adopt-data-3') });
   check('отсутствующий источник — не исключение, а причина', gone.ok === false && gone.reason === 'source_missing', JSON.stringify(gone));
+  // Старый бинарник остался на месте: на Node 24.x/Windows это штатный исход rmSync на путях
+  // с не-ASCII символами. Здесь неудаляемость моделируется каталогом по пути файла — важен не
+  // способ, а поведение: renameSync поверх живого пути Windows отвергает, и без проверки
+  // вызывающий получил бы исключение вместо причины. Мусор после отказа тоже не остаётся.
+  const dataRoot4 = join(WORK, 'adopt-data-4');
+  rmSync(dataRoot4, { recursive: true, force: true });
+  mkdirSync(boot.binaryPath(fake, dataRoot4), { recursive: true });
+  const stale = await boot.adopt(fake, theirs, { root: dataRoot4 });
+  check('неудалённый старый бинарник — причина, а не исключение', stale.ok === false && stale.reason === 'stale_target', JSON.stringify(stale));
+  check('после отказа не остаётся ни временного файла, ни маркера',
+    !existsSync(`${boot.binaryPath(fake, dataRoot4)}.download`) && !existsSync(join(boot.installDir(fake, dataRoot4), '.ready')));
+
 
   // Дальше проверяется порядок разрешения, поэтому каталог данных подменяется на пустой:
   // иначе тест увидел бы установку той машины, на которой запущен, и означал бы разное в

--- a/tools/analyzer-bootstrap.mjs
+++ b/tools/analyzer-bootstrap.mjs
@@ -17,7 +17,7 @@
  *   node analyzer-bootstrap.mjs [--force] [--verify]
  */
 
-import { createWriteStream, createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, rmSync, chmodSync, statSync, copyFileSync } from 'node:fs';
+import { createWriteStream, createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, chmodSync, statSync, copyFileSync } from 'node:fs';
 import { removeFileSync } from './fs-safe.mjs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
@@ -152,7 +152,14 @@ export async function install(manifest, { root = dataRoot(), force = false, log 
     return { ok: false, reason: 'checksum_mismatch', actual, expected: target.sha256 };
   }
 
-  removeFileSync(finalPath);
+  // Удаление старого бинарника обязано ПОДТВЕРДИТЬСЯ: renameSync на существующий путь
+  // Windows отвергает, и вместо честного отказа вызывающий получил бы исключение из недр
+  // установки. Причина живого остатка та же, что у маркера гейта, — rmSync на путях с
+  // не-ASCII символами (имя пользователя Windows кириллицей — обычное дело).
+  if (!removeFileSync(finalPath)) {
+    removeFileSync(tmpPath);
+    return { ok: false, reason: 'stale_target', path: finalPath };
+  }
   renameSync(tmpPath, finalPath);
   if (process.platform !== 'win32') chmodSync(finalPath, 0o755);
   writeMarker(manifest, root, { sha256: actual, size: statSync(finalPath).size, installedFrom: url });
@@ -186,22 +193,29 @@ export async function adopt(manifest, sourcePath, { root = dataRoot(), log = () 
   const tmpPath = `${finalPath}.download`;
 
   try {
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     copyFileSync(sourcePath, tmpPath);
   } catch (e) {
     // На Windows лаунчер может держать свой файл открытым. Это не дефект и не повод падать:
     // вызывающий просто скачает бинарник обычным путём.
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     return { ok: false, reason: 'copy_failed', error: String(e.message || e) };
   }
 
   const actual = await sha256(tmpPath);
   if (actual !== target.sha256) {
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     return { ok: false, reason: 'checksum_mismatch', actual, expected: target.sha256 };
   }
 
-  rmSync(finalPath, { force: true });
+  // Удаление старого бинарника обязано ПОДТВЕРДИТЬСЯ: renameSync на существующий путь
+  // Windows отвергает, и вместо честного отказа вызывающий получил бы исключение из недр
+  // установки. Причина живого остатка та же, что у маркера гейта, — rmSync на путях с
+  // не-ASCII символами (имя пользователя Windows кириллицей — обычное дело).
+  if (!removeFileSync(finalPath)) {
+    removeFileSync(tmpPath);
+    return { ok: false, reason: 'stale_target', path: finalPath };
+  }
   renameSync(tmpPath, finalPath);
   if (process.platform !== 'win32') chmodSync(finalPath, 0o755);
   writeMarker(manifest, root, { sha256: actual, size: statSync(finalPath).size, installedFrom: sourcePath });

--- a/tools/analyzer-bootstrap.mjs
+++ b/tools/analyzer-bootstrap.mjs
@@ -18,6 +18,7 @@
  */
 
 import { createWriteStream, createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, rmSync, chmodSync, statSync, copyFileSync } from 'node:fs';
+import { removeFileSync } from './fs-safe.mjs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
@@ -138,20 +139,20 @@ export async function install(manifest, { root = dataRoot(), force = false, log 
     if (!response.ok || !response.body) {
       return { ok: false, reason: 'download_failed', status: response.status };
     }
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     await pipeline(Readable.fromWeb(response.body), createWriteStream(tmpPath));
   } catch (e) {
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     return { ok: false, reason: 'download_failed', error: String(e.message || e) };
   }
 
   const actual = await sha256(tmpPath);
   if (actual !== target.sha256) {
-    rmSync(tmpPath, { force: true });
+    removeFileSync(tmpPath);
     return { ok: false, reason: 'checksum_mismatch', actual, expected: target.sha256 };
   }
 
-  rmSync(finalPath, { force: true });
+  removeFileSync(finalPath);
   renameSync(tmpPath, finalPath);
   if (process.platform !== 'win32') chmodSync(finalPath, 0o755);
   writeMarker(manifest, root, { sha256: actual, size: statSync(finalPath).size, installedFrom: url });

--- a/tools/analyzer-run.mjs
+++ b/tools/analyzer-run.mjs
@@ -32,7 +32,8 @@
  * 2 — обязателен и недоступен, либо часовой не подтверждён.
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdtempSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, mkdirSync, readdirSync } from 'node:fs';
+import { removeTreeSync } from './fs-safe.mjs';
 import { join, dirname, resolve, relative, sep, isAbsolute, basename } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { homedir } from 'node:os';
@@ -514,10 +515,10 @@ export function runBslLs({ jar, root, configPath }) {
   const report = join(out, 'bsl-json.json');
   const text = existsSync(report) ? readFileSync(report, 'utf8') : '';
   try {
-    rmSync(out, { recursive: true, force: true });
+    removeTreeSync(out);
     // Промежуточный каталог убираем ТОЛЬКО пустым: параллельный прогон может держать в нём
     // свой отчёт, и рекурсивное удаление снесло бы чужой результат.
-    if (readdirSync(stage).length === 0) rmSync(stage, { recursive: true, force: true });
+    if (readdirSync(stage).length === 0) removeTreeSync(stage);
   } catch {
     /* уборка не критична */
   }

--- a/tools/fs-safe.mjs
+++ b/tools/fs-safe.mjs
@@ -1,0 +1,75 @@
+/**
+ * Надёжное удаление файлов и каталогов — с проверкой, что удаление состоялось.
+ *
+ * Зачем отдельный модуль. В Node 24.x на Windows `fs.rmSync` МОЛЧА не удаляет файл или
+ * каталог, если в пути есть не-ASCII символы (кириллица в имени проекта — обычное дело
+ * для 1С): ни исключения, ни удаления (nodejs/node#56049, nodejs/node#61067; исправления
+ * в апстриме есть, но до установленных версий доходят не сразу). Для гейта это фатально:
+ * `release` рапортовал «гейт снят», `qg-pending.json` оставался на месте — и Stop-хук
+ * блокировал завершение навсегда. Ровно тот класс отказа, против которого написан весь
+ * плагин: успех, не отличимый от невыполнения.
+ *
+ * Поэтому здесь два правила:
+ *   1) файлы удаляются `unlinkSync` — он не поражён этим дефектом;
+ *   2) после любого удаления результат ПРОВЕРЯЕТСЯ (`existsSync`), а для деревьев при
+ *      живом остатке выполняется ручной обход `unlinkSync` + `rmdirSync` — оба здоровы
+ *      на не-ASCII путях (проверено на Node 24.12.0 win32).
+ *
+ * Обе функции возвращают `true`, только если пути больше не существует. Вызывающий обязан
+ * смотреть на результат там, где от удаления зависит смысл сообщения пользователю.
+ */
+
+import { existsSync, unlinkSync, rmSync, rmdirSync, readdirSync, lstatSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Удаляет ФАЙЛ и подтверждает удаление. Отсутствующий файл — успех (удалять нечего).
+ */
+export function removeFileSync(path) {
+  try {
+    unlinkSync(path);
+  } catch (e) {
+    if (e && e.code !== 'ENOENT') return !existsSync(path);
+  }
+  return !existsSync(path);
+}
+
+/** Ручной обход дерева: unlink для файлов, rmdir для опустевших каталогов. */
+function removeTreeManual(path) {
+  let st;
+  try {
+    st = lstatSync(path);
+  } catch {
+    return; // уже нет — и хорошо
+  }
+  if (st.isDirectory() && !st.isSymbolicLink()) {
+    for (const entry of readdirSync(path)) removeTreeManual(join(path, entry));
+    try {
+      rmdirSync(path);
+    } catch {
+      /* итог проверит вызывающий */
+    }
+  } else {
+    try {
+      unlinkSync(path);
+    } catch {
+      /* итог проверит вызывающий */
+    }
+  }
+}
+
+/**
+ * Удаляет дерево (файл или каталог) и подтверждает удаление.
+ *
+ * Сначала штатный `rmSync` — на здоровых путях он быстрее и переживает ситуации,
+ * которые ручной обход не знает. Затем проверка; остаток добирается ручным обходом.
+ */
+export function removeTreeSync(path) {
+  try {
+    rmSync(path, { recursive: true, force: true });
+  } catch {
+    /* добьём обходом ниже */
+  }
+  if (existsSync(path)) removeTreeManual(path);
+  return !existsSync(path);
+}

--- a/tools/gate.mjs
+++ b/tools/gate.mjs
@@ -12,11 +12,12 @@
  *   node gate.mjs release --class C0 --reason "<...>"  # снять как не требующий проверки
  */
 
-import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { validate } from './evidence-validator.mjs';
 import { resolveProjectRoot } from './project-root.mjs';
 import { readConfig, versionSuffix, pluginVersion } from './config.mjs';
+import { removeFileSync } from './fs-safe.mjs';
 
 const STATE_DIR = ['.claude', '.state'];
 const PENDING = 'qg-pending.json';
@@ -274,11 +275,24 @@ function cmdRelease(args) {
 
   // Снимаем ТОЛЬКО свою сессию: записи остальных остаются взведёнными, за них отвечают
   // их владельцы. Если своя была последней — файл состояния удаляется целиком.
+  //
+  // Удаление обязано ПОДТВЕРДИТЬСЯ до того, как пользователю сказано «гейт снят»:
+  // на Node 24.x/Windows `rmSync` молча не удаляет файлы на путях с не-ASCII символами
+  // (кириллическое имя проекта — норма для 1С), и без проверки release рапортовал успех,
+  // а Stop-хук продолжал блокировать завершение. Успех, не отличимый от невыполнения, —
+  // ровно тот класс отказа, против которого написан весь плагин.
   delete state.sessions[sessionId];
   if (Object.keys(state.sessions).length) {
     writeFileSync(pending, JSON.stringify(state, null, 2), 'utf8');
-  } else {
-    rmSync(pending, { force: true });
+  } else if (!removeFileSync(pending)) {
+    process.stderr.write(
+      'Маркер гейта не удалился — гейт НЕ снят:\n' +
+        `  ${pending}\n` +
+        'Известная причина: fs.rmSync в Node 24.x на Windows молча пропускает пути\n' +
+        'с не-ASCII символами (nodejs/node#56049). Обнови Node до версии с исправлением\n' +
+        'либо удали файл вручную и повтори снятие.\n'
+    );
+    return 2;
   }
 
   let doneState = { version: 2, sessions: {} };


### PR DESCRIPTION
Перенос PR #3 (@andromanpro) на текущий main с двумя доработками. Авторский коммит перенесён
как есть, авторство сохранено.

## Что чинится

`gate.mjs release` печатал «Гейт снят», писал журнал — а `qg-pending.json` оставался на месте,
и Stop-хук блокировал завершение навсегда. Причина не в плагине: в Node 23/24 на Windows
`fs.rmSync` молча не удаляет пути с не-ASCII символами (nodejs/node#56049, nodejs/node#61067 —
подтверждено на 24.12.0/win32, на 22.10 дефекта нет). Кириллическое имя каталога для 1С — норма.

Решение автора: `tools/fs-safe.mjs` с `removeFileSync` / `removeTreeSync` — удаление через
`unlinkSync`/`rmdirSync` (не поражены) и обязательное подтверждение через `existsSync`. `release`
теперь проверяет, что маркер исчез, и при живом маркере отказывает с кодом 2 вместо ложного
успеха.

## Что добавлено при переносе

**Приём чужой установки анализатора.** Функция `adopt` появилась в v2.6.0, уже после исходного
PR, и осталась на `rmSync` — дефект вернулся ровно туда, откуда его убирали: путь ведёт в каталог
данных плагина и содержит имя пользователя Windows. Переведена на безопасное удаление, добавлена
причина `stale_target`: удаление старого бинарника подтверждается до `renameSync`, иначе вызывающий
получал исключение из недр установки вместо внятного отказа. То же подтверждение добавлено в
скачивание. Новый тест моделирует неудаляемый бинарник и проверяет, что после отказа не остаётся
ни временного файла, ни маркера.

**Матрица CI.** Прогон только на `ubuntu-latest` + Node 20 слеп к этому классу отказов в принципе:
инструменты запускает тот `node`, что стоит у пользователя, а дефект живёт в Node 23/24 на Windows.
Теперь `ubuntu-latest`/`windows-latest` × Node 20/24. Тесты создают каталог с кириллическим именем,
поэтому комбинация windows + 24 прогоняет фикс через затронутый кодовый путь по-настоящему.

## Проверка

- `node tests/run-tests.mjs` — 596 пройдено, 0 провалено (Node 20.18/win32);
- `node tools/validate-package.mjs` — 0 ошибок, 0 предупреждений;
- конфликт с main был один — строка импорта в `tools/analyzer-bootstrap.mjs`, где v2.6.0 добавила
  `copyFileSync`/`statSync`.

Закрывает #3.